### PR TITLE
remove @types from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ A React hook that handles clicks outside of a given element and calls a provided
     // Install the package
     npm install react-outside-click-hook
 
-    // Install Typescript Types
-    npm install --save-dev @types/react-outside-click-hook
-
 # Usage
 
 ### Arguments


### PR DESCRIPTION
you already have types in package and package `@types/react-outside-click-hook` does not exist